### PR TITLE
feat: 퍼블릭 S3 CSV 다운로드 기능 구현 (Fire CLI 기반)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,2 @@
+S3_URL=https://mloops2.s3.amazonaws.com/apt_trade_data.csv
+OUTPUT_FILENAME=apt_local_copy.csv

--- a/.env.template
+++ b/.env.template
@@ -1,2 +1,1 @@
-S3_URL=https://mloops2.s3.amazonaws.com/apt_trade_data.csv
-OUTPUT_FILENAME=apt_local_copy.csv
+S3_URL=

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,6 +44,8 @@ eli5==0.16.0
 geopy==2.4.1
 xyzservices
 mlxtend
+python-dotenv
+tqdm
 
 # Web
 Flask==3.1.0

--- a/src/dataset/data_loader.py
+++ b/src/dataset/data_loader.py
@@ -1,0 +1,43 @@
+import boto3
+import pandas as pd
+import io
+import os
+import fire
+
+
+class S3DataSaver:
+    def download_csv(self, bucket_name, object_key, output_path, aws_profile=None):
+        """
+        S3에서 데이터를 받아 CSV로 저장합니다.
+
+        Args:
+            bucket_name (str): S3 버킷 이름
+            object_key (str): S3 내부 경로 (예: 'data/apt_trade_data.csv')
+            output_path (str): 저장할 CSV 경로 (예: '/shared_data/raw_data.csv')
+            aws_profile (str, optional): AWS 프로파일 이름 (도커 외부에서 테스트할 때 사용)
+        """
+
+        # AWS 세션 설정
+        if aws_profile:
+            session = boto3.Session(profile_name=aws_profile)
+        else:
+            # 도커 환경에서는 환경변수로 인증함
+            session = boto3.Session()
+
+        s3 = session.client("s3")
+
+        # 객체 가져오기
+        print(f"Downloading s3://{bucket_name}/{object_key} ...")
+        obj = s3.get_object(Bucket=bucket_name, Key=object_key)
+        df = pd.read_csv(io.BytesIO(obj['Body'].read()))
+
+        # 디렉토리 없으면 생성
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+
+        # CSV 저장
+        df.to_csv(output_path, index=False)
+        print(f"Saved to {output_path}")
+
+
+if __name__ == '__main__':
+    fire.Fire(S3DataSaver)

--- a/src/dataset/data_loader.py
+++ b/src/dataset/data_loader.py
@@ -8,20 +8,18 @@ import os
 
 class S3PublicCSVDownloader:
     def download_csv(self,
-                     url: str = None,
-                     output_filename: str = None):
+                     output_filename: str = "apt_local_copy.csv"):
         
         """
         퍼블릭 S3 URL에서 CSV 파일을 다운로드하고, 진행률을 표시하며 로컬에 저장합니다.
-        URL과 파일명은 .env에서 불러옵니다.
+        파일명은 "apt_local_copy.csv"로 기본 설정되어 있으며,
+        URL은 .env에서 불러옵니다.
         """
 
         load_dotenv()
 
         # .env에서 기본값 불러오기
         url = os.getenv("S3_URL")
-        output_filename = os.getenv("OUTPUT_FILENAME", "apt_local_copy.csv")
-
         if not url:
             print("[ERROR] URL이 제공되지 않았습니다. .env에 S3_URL을 설정하세요.")
             return

--- a/src/dataset/data_loader.py
+++ b/src/dataset/data_loader.py
@@ -3,18 +3,28 @@ import fire
 import requests
 from tqdm import tqdm
 import io
+from dotenv import load_dotenv
+import os
 
 class S3PublicCSVDownloader:
     def download_csv(self,
-                     url: str = "https://mloops2.s3.amazonaws.com/apt_trade_data.csv",
-                     output_filename: str = "apt_local_copy.csv"):
+                     url: str = None,
+                     output_filename: str = None):
+        
         """
         퍼블릭 S3 URL에서 CSV 파일을 다운로드하고, 진행률을 표시하며 로컬에 저장합니다.
-
-        Args:
-            url (str): 퍼블릭 CSV 파일 URL (기본값: https://mloops2.s3.amazonaws.com/apt_trade_data.csv)
-            output_filename (str): 로컬에 저장할 파일명 (기본값: apt_local_copy.csv)
+        URL과 파일명은 .env에서 불러옵니다.
         """
+
+        load_dotenv()
+
+        # .env에서 기본값 불러오기
+        url = os.getenv("S3_URL")
+        output_filename = os.getenv("OUTPUT_FILENAME", "apt_local_copy.csv")
+
+        if not url:
+            print("[ERROR] URL이 제공되지 않았습니다. .env에 S3_URL을 설정하세요.")
+            return
         print(f"[INFO] 다운로드 시작: {url}")
 
         try:


### PR DESCRIPTION
## Summary
퍼블릭 S3 URL로부터 CSV 파일을 다운로드하고, 진행률 표시 및 로컬 저장을 지원하는 기능을 CLI 형태로 구현했습니다.

- `requests`로 스트리밍 다운로드
- `tqdm`으로 다운로드 진행률 표시
- 메모리에서 pandas DataFrame으로 처리 후 로컬 저장
- `fire`를 통해 CLI 명령어 실행 가능

## Proposed Changes
- `S3PublicCSVDownloader` 클래스 작성
- `download_csv` 메서드 구현: 기본 URL 및 파일명 인자 설정 포함
- 예외 처리 및 로그 출력 (`[INFO]`, `[SUCCESS]`, `[ERROR]`)
- `__main__`에서 fire 연결

## To Reviewers
- 다른 S3 URL도 테스트 가능하도록 기본 URL은 파라미터로 분리해두었습니다.
- CLI 테스트는 다음 명령어로 가능합니다:
python data_loader.py download_csv
